### PR TITLE
Update README for signed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ See the [releases page](https://github.com/andyshinn/alpine-pkg-glibc/releases) 
 
 ## Installing
 
-The current installation method for these packages is to pull them in using `wget` or `curl` and install the local file with the `--allow-untrusted` option to `apk`:
+The current installation method for these packages is to pull them in using `wget` or `curl` and install the local file with `apk`:
 
 ```
 apk --no-cache add ca-certificates
-wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.22-r5/glibc-2.22-r5.apk
-apk --allow-untrusted add glibc-2.22-r5.apk
+wget -q -O /etc/apk/keys/andyshinn.rsa.pub https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/andyshinn.rsa.pub
+wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-2.23-r1.apk
+apk add glibc-2.22-r5.apk
 ```
 
 ## Locales
@@ -23,6 +24,6 @@ apk --allow-untrusted add glibc-2.22-r5.apk
 You will need to generate your locale if you would like to use a specific one for your glibc application. You can do this by installing the `glibc-i18n` package and generating a locale using the `localedef` binary. An example for en_US.UTF-8 would be:
 
 ```
-apk --allow-untrusted add glibc-bin-2.22-r5.apk glibc-i18n-2.22-r5.apk
+apk add glibc-bin-2.22-r5.apk glibc-i18n-2.22-r5.apk
 /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8
 ```


### PR DESCRIPTION
The glibc* packages are now signed and no longer require the use of
the --allow-untrusted flag to apk.  This updates the README to show how
to install Andy's key to ensure the downloaded packages are signed.